### PR TITLE
Restart on new pageview

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,6 +61,18 @@ Appcues.prototype.load = function(callback) {
 };
 
 /**
+ * Page.
+ *
+ * http://appcues.com/docs#start
+ *
+ * @api public
+ */
+
+Appcues.prototype.page = function() {
+  window.Appcues.start();
+};
+
+/**
  * Identify.
  *
  * http://appcues.com/docs#identify

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -74,6 +74,18 @@ describe('Appcues', function() {
       analytics.page();
     });
 
+    describe('#page', function() {
+      beforeEach(function() {
+        analytics.stub(window.Appcues, 'start');
+      });
+
+      it('should proxy to Appcues.start()', function() {
+        analytics.didNotCall(window.Appcues.start);
+        analytics.page('Pricing');
+        analytics.called(window.Appcues.start);
+      });
+    });
+
     describe('#identify', function() {
       beforeEach(function() {
         analytics.stub(window.Appcues, 'identify');


### PR DESCRIPTION
This fixes cases for single-page apps like Angular that use the browser history API to change the page without a reload. This way, Appcues is still notified of the page change.
