### PR TITLE
Remove assumePageview

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,6 @@ var load = require('@segment/load-script');
  */
 
 var Appcues = integration('Appcues')
-  .assumesPageview()
   .global('Appcues')
   .option('appcuesId', '');
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -38,7 +38,6 @@ describe('Appcues', function() {
 
   it('should have the right settings', function() {
     analytics.compare(Appcues, integration('Appcues')
-      .assumesPageview()
       .global('Appcues')
       .option('appcuesId', ''));
   });
@@ -55,7 +54,6 @@ describe('Appcues', function() {
     describe('#initialize', function() {
       it('should call #load', function() {
         analytics.initialize();
-        analytics.page();
         analytics.called(appcues.load);
       });
     });
@@ -71,7 +69,6 @@ describe('Appcues', function() {
     beforeEach(function(done) {
       analytics.once('ready', done);
       analytics.initialize();
-      analytics.page();
     });
 
     describe('#page', function() {


### PR DESCRIPTION
We no longer depend on `page` already having been called, and in fact, we actually want to get the first `page` call.

One question to the reviewer: is [`.readyOnLoad()`](https://github.com/segmentio/analytics.js-integration#readyonload) necessary? From what I could tell, it doesn't actually do anything.
